### PR TITLE
Fix platform value for Portenta

### DIFF
--- a/library.json
+++ b/library.json
@@ -31,7 +31,7 @@
   },
   "license": "LGPL-3.0",
   "frameworks": "*",
-  "platforms": "mbed_portenta",
+  "platforms": "ststm32",
   "examples": "examples/*/*/*.ino",
   "headers": "Portenta_H7_AsyncTCP.h"
 }


### PR DESCRIPTION
There is no `mbed_portenta` platform in PlatformIO, the Portenta H7 board belongs to `ststm32`.